### PR TITLE
Sort events by event's date

### DIFF
--- a/_layouts/events_index.html
+++ b/_layouts/events_index.html
@@ -7,8 +7,8 @@
 			<h1>{{ page.title }}</h1>
 		</div>
 	</div>
-	{% assign featured_events = site.events | where:"is_featured","true" %}
-	{% for event in featured_events reversed  %}
+	{% assign featured_events = site.events | where:"is_featured","true" | sort: 'event_date'%}
+	{% for event in featured_events %}
 		<div class="row linked stacked EventsItem">
 			<div class="column col-xs-12 col-md-6">
 				<h3>Featured Event</h3>
@@ -23,8 +23,8 @@
 			<div class="BreakLine"></div>
 		</div>
 	{% endfor %}
-	{% assign not_featured_events = site.events | where:"is_featured","false" %}
-	{% for event in not_featured_events reversed  %}
+	{% assign not_featured_events = site.events | where:"is_featured","false" | sort: 'event_date' %}
+	{% for event in not_featured_events %}
 		<div class="row linked stacked EventsItem">
 			<div class="column post col-xs-12 col-md-7">
 				<h2><a class="NoUnderlined" href="{{ event.url }}">{{ event.title}}</a></h2>


### PR DESCRIPTION
Simple adjustment so events listed at `/events` are no longer listing out by date created but rather `event_date`